### PR TITLE
Proxy Auth fix

### DIFF
--- a/src/sip-client.coffee
+++ b/src/sip-client.coffee
@@ -69,7 +69,7 @@ Client.prototype.receive = (data)->
 			challenge.realm = challenge.realm.replace(/"/g, '')
 			request.inc_cseq()
 			response = digest.signRequest([challenge], request, msg, {user: @options.user, realm: challenge.realm, password:@options.password})
-			@send (sip.stringify(response))
+			@send (sip.stringify(request))
 
 
 

--- a/src/sip-client.coffee
+++ b/src/sip-client.coffee
@@ -68,7 +68,7 @@ Client.prototype.receive = (data)->
 			challenge = msg.headers[challenge_header][0]
 			challenge.realm = challenge.realm.replace(/"/g, '')
 			request.inc_cseq()
-			response = digest.signRequest([challenge], request, msg, {user: @options.user, realm: challenge.realm, password:@options.password})
+			digest.signRequest([challenge], request, msg, {user: @options.user, realm: challenge.realm, password:@options.password})
 			@send (sip.stringify(request))
 
 


### PR DESCRIPTION
digest.signRequest modifies headers in the request object passed in to it, so that's what should be sent back. This fix was tested with Twilio SIP Domain.